### PR TITLE
Include note about unreleased suspense for data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple Axios hook for React. Use React Suspense to show loading indicator and Error Boundary to show request errors.
 
+> ⚠️ Please note that as of yet (2019-10) unstable parts of the React API were used to create this library. You might need to update your version of `use-axios` if the API is changed in a future version of React. 
+
 > **Note** - This is a React hook for data fetching inside a function component body. Use `axios` for requests in `onSubmit`, `onClick` etc.
 
 ## Install


### PR DESCRIPTION
I think this should be included as the React team recently stated that they're still making changes to the suspense API and the current implementation has not been declared stable yet. See https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#an-update-to-the-roadmap